### PR TITLE
feat: 각 페이지 naviBar의 navigation 설정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-
+    implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/java/com/android/hangyul/MainActivity.kt
+++ b/app/src/main/java/com/android/hangyul/MainActivity.kt
@@ -7,11 +7,14 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.android.hangyul.navigation.NavGraph
+import androidx.navigation.compose.rememberNavController
 import com.android.hangyul.ui.theme.HangyulTheme
+import com.android.hangyul.ui.components.NaviBar
+import com.android.hangyul.ui.components.TopBar
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,29 +22,30 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             HangyulTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                val navController = rememberNavController()
+
+                val currentRoute = navController
+                    .currentBackStackEntryAsState().value
+                    ?.destination?.route
+
+                val topBarTitle = when (currentRoute) {
+                    "main" -> "한결이"
+                    "diary" -> "음성 일기"
+                    "routine" -> "일상 관리"
+                    "brainTraining" -> "두뇌 훈련"
+                    "memory" -> "추억 기록"
+                    else -> "한결이"
+                }
+
+                Scaffold(modifier = Modifier.fillMaxSize(),
+                    topBar = {TopBar(topBarTitle)},
+                    bottomBar = {NaviBar(navController)})
+                { innerPadding ->
+                    NavGraph(
+                        navController = navController,
+                        modifier = Modifier.padding(innerPadding))
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    HangyulTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -1,2 +1,25 @@
 package com.android.hangyul.navigation
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import com.android.hangyul.ui.screen.braintraining.BrainTrainingPage
+import com.android.hangyul.ui.screen.diary.DiaryPage
+import com.android.hangyul.ui.screen.main.MainPage
+import com.android.hangyul.ui.screen.memory.MemoryPage
+import com.android.hangyul.ui.screen.routine.RoutinePage
+
+
+@Composable
+fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
+    NavHost(navController = navController, startDestination = "main", modifier = modifier) {
+        composable("main") {MainPage(navController)}
+        composable("brainTraining") { BrainTrainingPage(navController)}
+        composable("routine") { RoutinePage(navController) }
+        composable("diary") { DiaryPage(navController) }
+        composable("memory") { MemoryPage(navController) }
+
+    }
+}

--- a/app/src/main/java/com/android/hangyul/ui/components/NaviBar.kt
+++ b/app/src/main/java/com/android/hangyul/ui/components/NaviBar.kt
@@ -1,8 +1,10 @@
 package com.android.hangyul.ui.components
 
+import android.health.connect.datatypes.ExerciseRoute
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,24 +25,26 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import com.android.hangyul.R
+import androidx.compose.foundation.layout.navigationBarsPadding
+
 
 @Composable
-fun NaviBar() {
+fun NaviBar(navController: NavController) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(90.dp)
             .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
             .background(Color.White)
             .border(
                 width = 0.5.dp,
                 color = Color.Gray,
             )
-            .padding(vertical = 12.dp, horizontal = 16.dp)
+            .padding(top = 12.dp, start = 16.dp, end = 16.dp, bottom = 12.dp)
+            .navigationBarsPadding()
 
     ) {
         Row(
@@ -48,20 +52,26 @@ fun NaviBar() {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            NavItem(R.drawable.ic_nav_diary, "음성 일기")
-            NavItem(R.drawable.ic_nav_routine, "일상 관리")
-            NavItem(R.drawable.ic_nav_main, "홈")
-            NavItem(R.drawable.ic_nav_braintraining, "두뇌 훈련")
-            NavItem(R.drawable.ic_nav_memory, "추억 기록")
+            NavItem(R.drawable.ic_nav_diary, "음성 일기", navController, "diary")
+            NavItem(R.drawable.ic_nav_routine, "일상 관리", navController, "routine")
+            NavItem(R.drawable.ic_nav_main, "홈", navController, "main")
+            NavItem(R.drawable.ic_nav_braintraining, "두뇌 훈련", navController, "brainTraining")
+            NavItem(R.drawable.ic_nav_memory, "추억 기록", navController, "memory")
 
         }
     }
 }
 
 @Composable
-fun NavItem(icon:Int, page: String) {
+fun NavItem(icon:Int, page: String, navController: NavController, route: String) {
     Column (
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.clickable {
+            navController.navigate(route) {
+                launchSingleTop = true
+                restoreState = true
+            }
+        }
     ){
         Image(
             painter = painterResource(id = icon),
@@ -75,12 +85,8 @@ fun NavItem(icon:Int, page: String) {
             fontFamily = FontFamily(Font(R.font.pretendard_medium)),
             fontWeight = FontWeight.Medium
         )
+        Spacer(modifier = Modifier.height(10.dp))
     }
 }
 
-@Preview
-@Composable
-fun NaviBarPreview() {
-    NaviBar()
-}
 

--- a/app/src/main/java/com/android/hangyul/ui/screen/braintraining/BrainTrainingPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/braintraining/BrainTrainingPage.kt
@@ -1,25 +1,20 @@
 package com.android.hangyul.ui.screen.braintraining
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
 import com.android.hangyul.ui.components.NaviBar
 import com.android.hangyul.ui.components.TopBar
 
 @Composable
-fun BrainTrainingPage() {
-    Scaffold (
-        topBar = {
-            TopBar("두뇌 훈련")
-        },
-        bottomBar = {
-            NaviBar()
-        }
-    ){  }
+fun BrainTrainingPage(navController: NavController) {
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text("두뇌훈련 페이지")
+    }
 }
-
-@Preview
-@Composable
-fun BrainTrainingPagePreview() {
-    BrainTrainingPage()
-}
-

--- a/app/src/main/java/com/android/hangyul/ui/screen/diary/DiaryPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/diary/DiaryPage.kt
@@ -1,25 +1,21 @@
 package com.android.hangyul.ui.screen.diary
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
 import com.android.hangyul.ui.components.NaviBar
 import com.android.hangyul.ui.components.TopBar
 
 @Composable
-fun DiaryPage() {
-    Scaffold (
-        topBar = {
-            TopBar("음성 일기")
-        },
-        bottomBar = {
-            NaviBar()
-        }
-    ){  }
-}
-
-@Preview
-@Composable
-fun DiaryPagePreview() {
-    DiaryPage()
+fun DiaryPage(navController: NavController) {
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text("음성 일기 페이지") // 예시
+    }
 }

--- a/app/src/main/java/com/android/hangyul/ui/screen/main/MainPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/main/MainPage.kt
@@ -1,4 +1,0 @@
-package com.android.hangyul.ui.screen.main
-
-class MainPage {
-}

--- a/app/src/main/java/com/android/hangyul/ui/screen/main/MainScreen.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/main/MainScreen.kt
@@ -1,18 +1,18 @@
-package com.android.hangyul.ui.screen.routine
+package com.android.hangyul.ui.screen.main
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.material3.Text
 import androidx.navigation.NavController
 
-
 @Composable
-fun RoutinePage(navController: NavController) {
+fun MainPage(navController: NavController) {
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
-        Text("일상 관리 페이지") // 예시
+        Text("메인 페이지") // 예시
     }
 }
+

--- a/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryPage.kt
@@ -1,26 +1,21 @@
 package com.android.hangyul.ui.screen.memory
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
 import com.android.hangyul.ui.components.NaviBar
 import com.android.hangyul.ui.components.TopBar
-import com.android.hangyul.ui.screen.diary.DiaryPage
 
 @Composable
-fun MemoryPage() {
-    Scaffold (
-        topBar = {
-            TopBar("추억 기록")
-        },
-        bottomBar = {
-            NaviBar()
-        }
-    ){  }
-}
-
-@Preview
-@Composable
-fun MemoryPagePreview() {
-    MemoryPage()
+fun MemoryPage(navController: NavController) {
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Text("추억 기록 페이지") // 예시
+    }
 }


### PR DESCRIPTION
### 개요
naviBar의 네비게이션 설정 

### 목적
- 5개 페이지 naviBar에서 아이콘 클릭 시 페이지 이동 구현 

### 변경사항
- 각 페이지 기본 텍스트 깔아둠
- 아이콘 클릭 시 각 페이지 이동
- naviBar 하단 padding 설정 (안드로이드 시스템 바에  안 가리도록)

### (옵션) 화면 이미지 등
<img width="199" alt="image" src="https://github.com/user-attachments/assets/f48cbea9-c1bd-4f47-92c6-4a38438e16bf" />
