### PR TITLE
feat: routine의 알람 등록 페이지들 navigation 적용

### DIFF
--- a/app/src/main/java/com/android/hangyul/MainActivity.kt
+++ b/app/src/main/java/com/android/hangyul/MainActivity.kt
@@ -34,6 +34,8 @@ class MainActivity : ComponentActivity() {
                     "routine" -> "일상 관리"
                     "brainTraining" -> "두뇌 훈련"
                     "memory" -> "추억 기록"
+                    "alarmList" -> "일상 관리"
+                    "alarmAdd" -> "일상 관리"
                     else -> "한결이"
                 }
 

--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -1,7 +1,9 @@
 package com.android.hangyul.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -9,18 +11,36 @@ import com.android.hangyul.ui.screen.braintraining.BrainTrainingPage
 import com.android.hangyul.ui.screen.diary.DiaryPage
 import com.android.hangyul.ui.screen.main.MainPage
 import com.android.hangyul.ui.screen.memory.MemoryPage
+import com.android.hangyul.ui.screen.routine.AlarmAddPage
 import com.android.hangyul.ui.screen.routine.AlarmListPage
 import com.android.hangyul.ui.screen.routine.RoutinePage
+import com.android.hangyul.viewmodel.AlarmViewModel
 
+private object Routes {
+    const val MAIN = "main"
+    const val BRAIN_TRAINING = "brainTraining"
+    const val ROUTINE = "routine"
+    const val DIARY = "diary"
+    const val MEMORY = "memory"
+
+    const val ALARM_LIST = "alarmList"
+    const val ALARM_ADD = "alarmAdd"
+}
 
 @Composable
 fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
-    NavHost(navController = navController, startDestination = "main", modifier = modifier) {
-        composable("main") {MainPage(navController)}
-        composable("brainTraining") { BrainTrainingPage(navController)}
-        composable("routine") { RoutinePage(navController) }
-        composable("diary") { DiaryPage(navController) }
-        composable("memory") { MemoryPage(navController) }
+    NavHost(navController = navController, startDestination = Routes.MAIN, modifier = modifier) {
+        composable(Routes.MAIN) { MainPage(navController) }
+        composable(Routes.BRAIN_TRAINING) { BrainTrainingPage(navController) }
+        composable(Routes.ROUTINE) { RoutinePage(navController) }
+        composable(Routes.DIARY) { DiaryPage(navController) }
+        composable(Routes.MEMORY) { MemoryPage(navController) }
 
+        composable(Routes.ALARM_LIST) { AlarmListPage(navController) }
+        composable("alarmAdd") {
+            AlarmAddPage(viewModel = viewModel()) {
+                navController.popBackStack()
+            }
+        }
     }
 }

--- a/app/src/main/java/com/android/hangyul/ui/components/AddBtn.kt
+++ b/app/src/main/java/com/android/hangyul/ui/components/AddBtn.kt
@@ -26,11 +26,11 @@ import com.android.hangyul.ui.theme.Purple60
 import com.android.hangyul.ui.theme.Purple80
 
 @Composable
-fun AddBtn(text:String) {
+fun AddBtn(text:String, modifier: Modifier) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = modifier
             .width(138.dp)
             .height(56.dp)
             .background(color = Purple60, shape = RoundedCornerShape(size=28.dp))
@@ -51,10 +51,4 @@ fun AddBtn(text:String) {
             )
         )
     }
-}
-
-@Preview
-@Composable
-fun AddBtnPreview() {
-    AddBtn("추억 등록")
 }

--- a/app/src/main/java/com/android/hangyul/ui/components/AddInputField.kt
+++ b/app/src/main/java/com/android/hangyul/ui/components/AddInputField.kt
@@ -15,15 +15,18 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.android.hangyul.ui.theme.Gray80
 
 @Composable
-fun AddInputField(text: String) {
+fun AddInputField(
+    text: String,
+    onTextChanged: (String) -> Unit,
+    placeholderText: String) {
     var inputText by remember { mutableStateOf("") }
 
     TextField(
-        value = inputText,
-        onValueChange = { inputText = it },
+        value = text,
+        onValueChange = onTextChanged,
         placeholder = {
             Text(
-                text = text,
+                text = placeholderText,
                 color = Gray80
             )
         },
@@ -48,11 +51,5 @@ fun AddInputField(text: String) {
             errorIndicatorColor = Color.Transparent
         )
     )
-}
-
-@Preview
-@Composable
-fun addFieldPreview() {
-    AddInputField("test")
 }
 

--- a/app/src/main/java/com/android/hangyul/ui/components/ListBtn.kt
+++ b/app/src/main/java/com/android/hangyul/ui/components/ListBtn.kt
@@ -31,9 +31,10 @@ import com.android.hangyul.ui.theme.Purple80
 
 
 @Composable
-fun ListBtn(icon:Int, text:String, description:String) {
+fun ListBtn(icon:Int, text:String, description:String,
+            modifier: Modifier = Modifier) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .width(320.dp)
             .background(
                 brush = Brush.linearGradient(

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmAddPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmAddPage.kt
@@ -21,9 +21,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.hangyul.R
 import com.android.hangyul.ui.components.AddInputField
+import com.android.hangyul.viewmodel.AlarmViewModel
 
 @Composable
-fun AlarmAddPage(onTimeSelected: (Int, Int) -> Unit) {
+fun AlarmAddPage(viewModel: AlarmViewModel, onSave: ()->Unit) {
 
     Column (
         modifier = Modifier
@@ -46,9 +47,15 @@ fun AlarmAddPage(onTimeSelected: (Int, Int) -> Unit) {
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally
         ){
-            AddInputField("알람 이름")
+            AddInputField(
+                text = viewModel.alarmName,
+                onTextChanged = { viewModel.alarmName = it },
+                placeholderText = "알람 이름")
             Spacer(modifier = Modifier.height(10.dp))
-            AddInputField("약 이름")
+            AddInputField(
+                text = viewModel.medicineName,
+                onTextChanged = { viewModel.medicineName = it },
+                placeholderText = "약 이름")
         }
 
         Spacer(modifier = Modifier.height(35.dp))
@@ -65,20 +72,13 @@ fun AlarmAddPage(onTimeSelected: (Int, Int) -> Unit) {
 
         Spacer(modifier = Modifier.height(40.dp))
 
-        TimePicker(onTimeSelected = onTimeSelected)
+        TimePicker { hour, minute ->
+            viewModel.hour = hour
+            viewModel.minute = minute
+            onSave()
+        }
 
 
 
-    }
-}
-
-@Preview(
-    showBackground = true,
-    backgroundColor = 0xF1F0FF
-)
-@Composable
-fun AlarmAddPagePreview() {
-    AlarmAddPage{ hour, minute ->
-        println("Preview에서 선택한 시간: $hour:$minute")
     }
 }

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmListPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmListPage.kt
@@ -1,5 +1,6 @@
 package com.android.hangyul.ui.screen.routine
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,7 +24,7 @@ import com.android.hangyul.R
 import com.android.hangyul.ui.components.AddBtn
 
 @Composable
-fun AlarmListPage() {
+fun AlarmListPage(navController: NavController) {
     Column (
         modifier = Modifier
             .fillMaxSize()
@@ -53,17 +54,9 @@ fun AlarmListPage() {
                 .padding(end = 25.dp, bottom = 25.dp),
             horizontalArrangement = Arrangement.End
         ) {
-            AddBtn("알람 등록")
+            AddBtn("알람 등록", modifier = Modifier.clickable { navController.navigate("alarmAdd") })
         }
     }
 
 }
 
-@Preview(
-    showBackground = true,
-    backgroundColor = 0xFFFFFF
-)
-@Composable
-fun AlarmListPagePreview() {
-    AlarmListPage()
-}

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/RoutinePage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/RoutinePage.kt
@@ -1,5 +1,6 @@
 package com.android.hangyul.ui.screen.routine
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.android.hangyul.R
 import com.android.hangyul.ui.components.ListBtn
-import org.intellij.lang.annotations.JdkConstants.HorizontalAlignment
 
 data class routineList(
     val icon: Int,
@@ -49,7 +49,9 @@ fun RoutinePage(navController: NavController) {
             .padding(top = 20.dp),
 
     ){
-        ListBtn(medicine.icon, medicine.text, medicine.description)
+        ListBtn(medicine.icon, medicine.text, medicine.description, modifier = Modifier.clickable {
+            navController.navigate("alarmList")
+        })
         Spacer(modifier = Modifier.height(15.dp))
         ListBtn(location.icon, location.text, location.description)
     }

--- a/app/src/main/java/com/android/hangyul/viewmodel/AlarmViewModel.kt
+++ b/app/src/main/java/com/android/hangyul/viewmodel/AlarmViewModel.kt
@@ -1,0 +1,21 @@
+package com.android.hangyul.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class AlarmViewModel : ViewModel() {
+    var alarmName by mutableStateOf("")
+    var medicineName by mutableStateOf("")
+    var hour by mutableStateOf(0)
+    var minute by mutableStateOf(0)
+
+
+    fun reset() {
+        alarmName = ""
+        medicineName = ""
+        hour = 0
+        minute = 0
+    }
+}


### PR DESCRIPTION
### 개요
routine/alarm 관련 페이지 navigation 구현 

### 목적
routine 엔트리 페이지 -> alarmList 페이지 -> alarm등록 페이지 -> 저장 누르면 alarmList 페이지 

### 변경사항
- NavGraph 에 Routes object 정의 
- 일단 TimePicker등의 변수들 저장하는 건 로컬 데베 사용해둠 (viewModel)
- 나중에 외부 데베 연결하자 
