### PR TITLE
style: 추억 기록 관련 페이지 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,16 +2,7 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="app">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="GreetingPreview">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="GreetingPreview (1)">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="FeatureButtonGridPreview">
+      <SelectionState runConfigName="MainActivity">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
     </selectionStates>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,61 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="ComposePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ComposePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="GlancePreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/com/android/hangyul/MainActivity.kt
+++ b/app/src/main/java/com/android/hangyul/MainActivity.kt
@@ -36,6 +36,8 @@ class MainActivity : ComponentActivity() {
                     "memory" -> "추억 기록"
                     "alarmList" -> "일상 관리"
                     "alarmAdd" -> "일상 관리"
+                    "memoryDetail" -> "추억 기록"
+                    "memoryAdd" -> "추억 기록"
                     else -> "한결이"
                 }
 

--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -10,6 +10,8 @@ import androidx.navigation.compose.composable
 import com.android.hangyul.ui.screen.braintraining.BrainTrainingPage
 import com.android.hangyul.ui.screen.diary.DiaryPage
 import com.android.hangyul.ui.screen.main.MainPage
+import com.android.hangyul.ui.screen.memory.MemoryAddPage
+import com.android.hangyul.ui.screen.memory.MemoryDetailPage
 import com.android.hangyul.ui.screen.memory.MemoryPage
 import com.android.hangyul.ui.screen.routine.AlarmAddPage
 import com.android.hangyul.ui.screen.routine.AlarmListPage
@@ -25,6 +27,9 @@ private object Routes {
 
     const val ALARM_LIST = "alarmList"
     const val ALARM_ADD = "alarmAdd"
+
+    const val MEMORY_DETAIL = "memoryDetail"
+    const val MEMORY_ADD = "memoryAdd"
 }
 
 @Composable
@@ -37,10 +42,13 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
         composable(Routes.MEMORY) { MemoryPage(navController) }
 
         composable(Routes.ALARM_LIST) { AlarmListPage(navController) }
-        composable("alarmAdd") {
+        composable(Routes.ALARM_ADD) {
             AlarmAddPage(viewModel = viewModel()) {
                 navController.popBackStack()
             }
         }
+
+        composable(Routes.MEMORY_DETAIL) { MemoryDetailPage(navController)}
+        composable(Routes.MEMORY_ADD) { MemoryAddPage(viewModel = viewModel()) {navController.popBackStack() }}
     }
 }

--- a/app/src/main/java/com/android/hangyul/ui/screen/memory/ImageUploadBox.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/memory/ImageUploadBox.kt
@@ -1,0 +1,44 @@
+package com.android.hangyul.ui.screen.memory
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun ImageUploadBox(
+    imagePaths: List<String>,
+    onUploadClicked: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .width(300.dp)
+            .background(Color(0xFFF5F5F5), RoundedCornerShape(12.dp))
+            .padding(12.dp)
+    ) {
+        for (path in imagePaths) {
+            Text(
+                text = path,
+                fontSize = 14.sp,
+                color = Color.DarkGray
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // 업로드 버튼
+        Button(
+            onClick = { onUploadClicked() },
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        ) {
+            Text("사진 업로드")
+        }
+    }
+}

--- a/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryAddPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryAddPage.kt
@@ -1,0 +1,92 @@
+package com.android.hangyul.ui.screen.memory
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.hangyul.R
+import com.android.hangyul.ui.components.AddInputField
+import com.android.hangyul.viewmodel.MemoryViewModel
+
+@Composable
+fun MemoryAddPage(viewModel: MemoryViewModel, onSave: ()->Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 25.dp, vertical = 20.dp),
+    ) {
+        Text(
+            text = "추억을 기록하세요!",
+            style = TextStyle(
+                fontSize = 23.sp,
+                lineHeight = 30.sp,
+                fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+            )
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        AddInputField(
+            text = viewModel.title,
+            onTextChanged = { viewModel.title = it },
+            placeholderText = "제목을 입력하세요"
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        AddInputField(
+            text = viewModel.date,
+            onTextChanged = { viewModel.date = it },
+            placeholderText = "날짜"
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        AddInputField(
+            text = viewModel.content,
+            onTextChanged = { viewModel.content = it },
+            placeholderText = "내용을 입력하세요"
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        ImageUploadBox(
+            imagePaths = viewModel.images,
+            onUploadClicked = {
+                //TODO: 이미지 선택 로직 연결
+                viewModel.addImage("new_image_123.png")
+            }
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.weight(1f))
+
+        Button(
+            onClick = {
+                viewModel.saveMemory()
+                onSave()
+            },
+            modifier = Modifier
+                .width(300.dp)
+                .align(Alignment.CenterHorizontally)
+        )
+        {
+            Text("저장")
+        }
+    }
+}

--- a/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryDetailPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryDetailPage.kt
@@ -1,0 +1,99 @@
+package com.android.hangyul.ui.screen.memory
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.android.hangyul.R
+import com.android.hangyul.ui.components.AddBtn
+import androidx.compose.material3.Text
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.style.TextAlign
+
+
+@Composable
+fun MemoryDetailPage(navController: NavController) {
+    Column (
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 25.dp, vertical = 20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ){
+        Text(
+            text = "아들내미 집 놀러간 날",
+            style = TextStyle(
+                fontSize = 23.sp,
+                lineHeight = 30.sp,
+                fontFamily = FontFamily(Font(R.font.pretendard_bold)),
+            )
+        )
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Text(
+            text = "2025.05.27.",
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(end = 10.dp),
+            textAlign = TextAlign.End,
+            style = TextStyle(
+                fontSize = 14.sp,
+                lineHeight = 30.sp,
+                fontFamily = FontFamily(Font(R.font.pretendard_semibold)),
+                fontWeight = FontWeight(600),
+                color = Color(0xFF634F96),
+            )
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Box(
+            modifier = Modifier
+                .width(250.dp)
+                .height(180.dp)
+                .background(color = Color.Gray)
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Text(
+            text = "잘생긴 우리아들...~~\n무럭무럭 크려무나",
+            style = TextStyle(
+                fontSize = 23.sp,
+                lineHeight = 30.sp,
+                fontFamily = FontFamily(Font(R.font.pretendard_medium)),
+                fontWeight = FontWeight(500),
+                color = Color(0xFF000000),
+            )
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(end = 25.dp, bottom = 25.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            AddBtn("추억 등록", modifier = Modifier.clickable { navController.navigate("memoryAdd") })
+        }
+    }
+}

--- a/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryPage.kt
@@ -1,21 +1,58 @@
 package com.android.hangyul.ui.screen.memory
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.android.hangyul.R
+import com.android.hangyul.ui.components.AddBtn
+import com.android.hangyul.ui.components.ListBtn
 import com.android.hangyul.ui.components.NaviBar
 import com.android.hangyul.ui.components.TopBar
+import com.android.hangyul.ui.screen.routine.location
+import com.android.hangyul.ui.screen.routine.medicine
 
 @Composable
 fun MemoryPage(navController: NavController) {
-    Box(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Text("추억 기록 페이지") // 예시
+    val icon = R.drawable.ic_nav_memory
+    val title = "아들내미 집 놀러간 날"
+    val date = "2025.05.27."
+
+    Column  (
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 20.dp),
+
+        ){
+        ListBtn(icon, title, date, modifier = Modifier.clickable {
+            navController.navigate("memoryDetail")
+        })
+        Spacer(modifier = Modifier.height(15.dp))
+        Spacer(modifier = Modifier.weight(1f))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(end = 25.dp, bottom = 25.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            AddBtn("추억 등록", modifier = Modifier.clickable { navController.navigate("memoryAdd") })
+        }
     }
 }
+

--- a/app/src/main/java/com/android/hangyul/viewmodel/MemoryViewModel.kt
+++ b/app/src/main/java/com/android/hangyul/viewmodel/MemoryViewModel.kt
@@ -1,0 +1,21 @@
+package com.android.hangyul.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class MemoryViewModel : ViewModel() {
+    var title by mutableStateOf("")
+    var date by mutableStateOf("")
+    var content by mutableStateOf("")
+    var images by mutableStateOf(listOf<String>())
+
+    fun saveMemory() {
+        println("저장 완료: $title / $date / $content / $images")
+    }
+
+    fun addImage(path: String) {
+        images = images + path
+    }
+}


### PR DESCRIPTION
### 개요
추억 기록 관련 페이지 UI 구현

### 목적
- 추억 기록 엔트리 페이지 (== 추억 목록 페이지)
- 추억 등록 페이지
- 추억 등록 버튼 -> 네비게이션 구현 
- 사진 업로드 버튼 클릭 시 정보 실시간 출력 기능 

### 변경사항
- NavGraph에 memory 관련 라우터 추가
- MemoryViewModel 추가 

### (옵션) 화면 이미지 등
<img width="181" alt="image" src="https://github.com/user-attachments/assets/92fb9a9f-43bf-4419-87a4-cdd6ff2b5975" />
ㄴ 추억기록 엔트리 페이지
<img width="162" alt="image" src="https://github.com/user-attachments/assets/9522ad25-5db4-4bae-b79c-86f7e2ae5610" />
ㄴ 해당 추억 상세보기 페이지
<img width="169" alt="image" src="https://github.com/user-attachments/assets/0d982128-9c17-45ea-a084-0f5de7479314" />
ㄴ 추억 등록 버튼 클릭 시 이동하는 추억 등록 페이지 (사진 업로드 clickable 구현)