### PR TITLE
style: 지도 페이지 2개 UI 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,9 @@ dependencies {
     implementation("androidx.compose.material3:material3:1.2.0-beta01") // 또는 최신 버전
     implementation("androidx.compose.material3:material3:1.2.0-alpha05") // 시간 피커 포함
 
+    implementation ("com.google.maps.android:maps-compose:2.11.4")  // 지도 api
+    implementation ("com.google.android.gms:play-services-maps:18.1.0")
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
 
     implementation ("com.google.maps.android:maps-compose:2.11.4")  // 지도 api
     implementation ("com.google.android.gms:play-services-maps:18.1.0")
+    implementation ("com.google.android.libraries.places:places:3.3.0")
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
     implementation ("com.google.maps.android:maps-compose:2.11.4")  // 지도 api
     implementation ("com.google.android.gms:play-services-maps:18.1.0")
     implementation ("com.google.android.libraries.places:places:3.3.0")
+    implementation ("com.google.android.libraries.places:places:3.3.0") // 자동완성
+
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+
+
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -12,6 +15,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Hangyul"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="AIzaSyDz8UvMNJtUipKK2WRtKjB0IZqmTG1ih3M" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/android/hangyul/MainActivity.kt
+++ b/app/src/main/java/com/android/hangyul/MainActivity.kt
@@ -15,10 +15,12 @@ import androidx.navigation.compose.rememberNavController
 import com.android.hangyul.ui.theme.HangyulTheme
 import com.android.hangyul.ui.components.NaviBar
 import com.android.hangyul.ui.components.TopBar
+import com.google.android.libraries.places.api.Places
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Places.initialize(applicationContext, "AIzaSyDz8UvMNJtUipKK2WRtKjB0IZqmTG1ih3M")
         enableEdgeToEdge()
         setContent {
             HangyulTheme {

--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -1,6 +1,7 @@
 package com.android.hangyul.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalWithComputedDefaultOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -15,6 +16,8 @@ import com.android.hangyul.ui.screen.memory.MemoryDetailPage
 import com.android.hangyul.ui.screen.memory.MemoryPage
 import com.android.hangyul.ui.screen.routine.AlarmAddPage
 import com.android.hangyul.ui.screen.routine.AlarmListPage
+import com.android.hangyul.ui.screen.routine.MapListPage
+import com.android.hangyul.ui.screen.routine.MapMarkerAddPage
 import com.android.hangyul.ui.screen.routine.RoutinePage
 import com.android.hangyul.viewmodel.AlarmViewModel
 
@@ -30,6 +33,9 @@ private object Routes {
 
     const val MEMORY_DETAIL = "memoryDetail"
     const val MEMORY_ADD = "memoryAdd"
+
+    const val MAP_LIST = "mapList"
+    const val MAP_ADD = "mapAdd"
 }
 
 @Composable
@@ -50,5 +56,8 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
 
         composable(Routes.MEMORY_DETAIL) { MemoryDetailPage(navController)}
         composable(Routes.MEMORY_ADD) { MemoryAddPage(viewModel = viewModel()) {navController.popBackStack() }}
+
+        composable(Routes.MAP_LIST) { MapListPage(navController) }
+        composable(Routes.MAP_ADD) { MapMarkerAddPage()}
     }
 }

--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -58,6 +58,6 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
         composable(Routes.MEMORY_ADD) { MemoryAddPage(viewModel = viewModel()) {navController.popBackStack() }}
 
         composable(Routes.MAP_LIST) { MapListPage(navController) }
-        composable(Routes.MAP_ADD) { MapMarkerAddPage()}
+        composable(Routes.MAP_ADD) { MapMarkerAddPage(navController, viewModel = viewModel())}
     }
 }

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapListPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapListPage.kt
@@ -15,12 +15,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.android.hangyul.ui.components.AddBtn
+import com.android.hangyul.viewmodel.MapViewModel
 
 @Composable
-fun MapListPage(navController: NavController) {
+fun MapListPage(navController: NavController, viewModel: MapViewModel = viewModel()) {
+
+    val markerPosition = viewModel.selectedLocation
 
     Column (
         modifier = Modifier
@@ -29,7 +33,7 @@ fun MapListPage(navController: NavController) {
         verticalArrangement = Arrangement.SpaceBetween
 
     ){
-        MapViewScreen()
+        MapViewScreen(markerPosition)
 
         Spacer(modifier = Modifier.weight(1f))
 

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapListPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapListPage.kt
@@ -1,0 +1,52 @@
+package com.android.hangyul.ui.screen.routine
+
+import android.graphics.Color
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.android.hangyul.ui.components.AddBtn
+
+@Composable
+fun MapListPage(navController: NavController) {
+
+    Column (
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+
+    ){
+        MapViewScreen()
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(end = 25.dp, bottom = 25.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            AddBtn("장소 추가", modifier = Modifier.clickable { navController.navigate("mapAdd") })
+        }
+
+    }
+}
+
+@Preview (showBackground = true)
+@Composable
+fun MapListPagePreview() {
+    MapListPage(navController = rememberNavController())
+}

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapMarkerAddPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapMarkerAddPage.kt
@@ -1,12 +1,107 @@
 package com.android.hangyul.ui.screen.routine
 
+import android.content.Context
+import android.location.Geocoder
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.libraries.places.api.Places
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
+import java.util.Locale
+
+
+fun searchLocation(
+    context: Context,
+    query: String,
+    onResult: (LatLng) -> Unit
+) {
+    val geocoder = Geocoder(context, Locale.KOREA)
+    val addresses = geocoder.getFromLocationName(query, 1)
+    if (!addresses.isNullOrEmpty()) {
+        val location = addresses[0]
+        onResult(LatLng(location.latitude, location.longitude))
+    }
+}
+
 
 @Composable
 fun MapMarkerAddPage() {
+    val context = LocalContext.current
+    val defaultPosition = LatLng(35.1796, 129.0756) // 부산
 
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(defaultPosition, 12f)
+    }
+    var searchQuery by remember { mutableStateOf("") }
+    var markerPosition by remember { mutableStateOf<LatLng?>(null) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+
+        // 검색창
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = { searchQuery = it },
+            label = { Text("장소를 입력하세요") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = "검색") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        )
+
+        // 지도
+        GoogleMap(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            cameraPositionState = cameraPositionState
+        ) {
+            markerPosition?.let {
+                Marker(state = MarkerState(position = it))
+            }
+        }
+
+        // 검색 버튼
+        Button(
+            onClick = {
+                searchLocation(context, searchQuery) { latLng ->
+                    markerPosition = latLng
+                    cameraPositionState.move(
+                        CameraUpdateFactory.newLatLngZoom(latLng, 15f)
+                    )
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text("추가")
+        }
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapMarkerAddPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapMarkerAddPage.kt
@@ -1,0 +1,16 @@
+package com.android.hangyul.ui.screen.routine
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+
+@Composable
+fun MapMarkerAddPage() {
+
+}
+
+@Preview
+@Composable
+fun MapMarkerAddPagePreview() {
+    MapMarkerAddPage()
+}

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapViewScreen.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapViewScreen.kt
@@ -1,0 +1,47 @@
+package com.android.hangyul.ui.screen.routine
+
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Marker
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
+
+
+@Composable
+fun MapViewScreen() {
+    val context = LocalContext.current
+    val busanLatLng = LatLng(35.1796, 129.0756)
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(busanLatLng, 13f)
+    }
+
+    if(context != null) {
+        GoogleMap(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),  // 비율 조정
+            cameraPositionState = cameraPositionState
+        ) {
+            Marker(
+                state = MarkerState(position = busanLatLng),
+                title = "부산",
+                snippet = "대한민국"
+            )
+        }
+    }
+
+}
+
+@Preview
+@Composable
+fun MapViewScreenPreview() {
+    MapViewScreen()
+}

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapViewScreen.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapViewScreen.kt
@@ -15,7 +15,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
 
 
 @Composable
-fun MapViewScreen() {
+fun MapViewScreen(markerPosition: LatLng?) {
     val context = LocalContext.current
     val busanLatLng = LatLng(35.1796, 129.0756)
 
@@ -30,18 +30,16 @@ fun MapViewScreen() {
                 .aspectRatio(1f),  // 비율 조정
             cameraPositionState = cameraPositionState
         ) {
-            Marker(
-                state = MarkerState(position = busanLatLng),
-                title = "부산",
-                snippet = "대한민국"
-            )
+            markerPosition?.let{
+                Marker(
+                    state = MarkerState(position = busanLatLng),
+                    title = "부산",
+                    snippet = "대한민국"
+                )
+            }
+
         }
     }
 
 }
 
-@Preview
-@Composable
-fun MapViewScreenPreview() {
-    MapViewScreen()
-}

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/RoutinePage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/RoutinePage.kt
@@ -53,7 +53,9 @@ fun RoutinePage(navController: NavController) {
             navController.navigate("alarmList")
         })
         Spacer(modifier = Modifier.height(15.dp))
-        ListBtn(location.icon, location.text, location.description)
+        ListBtn(location.icon, location.text, location.description, modifier = Modifier.clickable {
+            navController.navigate("mapList")
+        })
     }
 }
 

--- a/app/src/main/java/com/android/hangyul/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/android/hangyul/viewmodel/MapViewModel.kt
@@ -1,4 +1,11 @@
 package com.android.hangyul.viewmodel
 
-class MapViewModel {
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+
+class MapViewModel : ViewModel(){
+
 }

--- a/app/src/main/java/com/android/hangyul/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/android/hangyul/viewmodel/MapViewModel.kt
@@ -4,8 +4,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.google.android.gms.maps.model.LatLng
 
 
 class MapViewModel : ViewModel(){
+    var selectedLocation by mutableStateOf<LatLng?> (null)
+        private set
 
+    fun setLocation(latLng: LatLng) {
+        selectedLocation = latLng
+    }
 }

--- a/app/src/main/java/com/android/hangyul/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/android/hangyul/viewmodel/MapViewModel.kt
@@ -1,0 +1,4 @@
+package com.android.hangyul.viewmodel
+
+class MapViewModel {
+}


### PR DESCRIPTION
### 개요
일상관리 -> 자주 가는 위치 페이지 UI 구현

### 목적
- 자주 가는 위치 페이지 구현
- 위치 등록하기 페이지 구현 (검색까지 해둔 상태)

### 변경사항
- manifest.xml 에 googld Map API_KEY 등록해둔 상태 (언니 앱 실행할 때 튕기면 이거 문제니까 나한테 연락해줘 언니 key도 등록해야함)
- gradle 지도 api 의존성 추가
- 지도 핑 찍은 위경도 정보 저장 -> mapViewModel 파일 추가
- 코루틴 구현 중임 (suspend 함수) -> 빌드 주의문 떠서 추후 조정 필요 

### (옵션) 화면 이미지 등
<img width="181" alt="image" src="https://github.com/user-attachments/assets/b0e0ba46-df73-454c-91f9-c3262765431d" />
ㄴ위치 핑 찍혀있(을) 페이지
<img width="181" alt="image" src="https://github.com/user-attachments/assets/631f2bd0-ae9b-4c03-9849-01302562927e" />
ㄴ 위치 추가 페이지