### PR TITLE
feat: 지도에서 위치 추가 및 Marker 표시 기능

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,19 @@
+import java.util.Properties
+
+val localProperties = Properties().apply {
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        load(localPropertiesFile.inputStream())
+    }
+}
+
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
+
 
 android {
     namespace = "com.android.hangyul"
@@ -16,6 +27,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField ("String", "MAPS_API_KEY", "\"${localProperties["MAPS_API_KEY"]}\"")
     }
 
     buildTypes {
@@ -36,6 +48,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="AIzaSyDz8UvMNJtUipKK2WRtKjB0IZqmTG1ih3M" />
+            android:value="MAP_API_KEY" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/android/hangyul/MainActivity.kt
+++ b/app/src/main/java/com/android/hangyul/MainActivity.kt
@@ -40,6 +40,8 @@ class MainActivity : ComponentActivity() {
                     "alarmAdd" -> "일상 관리"
                     "memoryDetail" -> "추억 기록"
                     "memoryAdd" -> "추억 기록"
+                    "mapList" -> "일상 관리"
+                    "mapAdd" -> "일상 관리"
                     else -> "한결이"
                 }
 

--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -20,6 +20,7 @@ import com.android.hangyul.ui.screen.routine.MapListPage
 import com.android.hangyul.ui.screen.routine.MapMarkerAddPage
 import com.android.hangyul.ui.screen.routine.RoutinePage
 import com.android.hangyul.viewmodel.AlarmViewModel
+import com.android.hangyul.viewmodel.MapViewModel
 
 private object Routes {
     const val MAIN = "main"
@@ -40,6 +41,7 @@ private object Routes {
 
 @Composable
 fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
+    val sharedMapViewModel: MapViewModel = viewModel()
     NavHost(navController = navController, startDestination = Routes.MAIN, modifier = modifier) {
         composable(Routes.MAIN) { MainPage(navController) }
         composable(Routes.BRAIN_TRAINING) { BrainTrainingPage(navController) }
@@ -57,7 +59,11 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
         composable(Routes.MEMORY_DETAIL) { MemoryDetailPage(navController)}
         composable(Routes.MEMORY_ADD) { MemoryAddPage(viewModel = viewModel()) {navController.popBackStack() }}
 
-        composable(Routes.MAP_LIST) { MapListPage(navController) }
-        composable(Routes.MAP_ADD) { MapMarkerAddPage(navController, viewModel = viewModel())}
+        composable(Routes.MAP_LIST) {
+            MapListPage(navController, sharedMapViewModel)
+        }
+        composable(Routes.MAP_ADD) {
+            MapMarkerAddPage(navController, sharedMapViewModel)
+        }
     }
 }

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapListPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapListPage.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -20,11 +23,29 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.android.hangyul.ui.components.AddBtn
 import com.android.hangyul.viewmodel.MapViewModel
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.rememberCameraPositionState
 
 @Composable
 fun MapListPage(navController: NavController, viewModel: MapViewModel = viewModel()) {
 
-    val markerPosition = viewModel.selectedLocation
+    val markerPositions by viewModel.selectedLocations.collectAsState()
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(
+            markerPositions.lastOrNull() ?: LatLng(35.1796, 129.0756), // 기본 부산
+            13f
+        )
+    }
+
+    LaunchedEffect(markerPositions) {
+        markerPositions.lastOrNull()?.let {
+            cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(it, 15f))
+        }
+    }
+
 
     Column (
         modifier = Modifier
@@ -33,7 +54,7 @@ fun MapListPage(navController: NavController, viewModel: MapViewModel = viewMode
         verticalArrangement = Arrangement.SpaceBetween
 
     ){
-        MapViewScreen(markerPosition)
+        MapViewScreen(markerPositions, cameraPositionState)
 
         Spacer(modifier = Modifier.weight(1f))
 

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapMarkerAddPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapMarkerAddPage.kt
@@ -116,7 +116,7 @@ fun MapMarkerAddPage(navController: NavController, viewModel: MapViewModel) {
         Button(
             onClick = {
                 markerPosition?.let {
-                    viewModel.setLocation(it)
+                    viewModel.addLocation(it)
                     navController.navigate("mapList") {
                         popUpTo("mapAdd") { inclusive = true }
                     }

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/MapViewScreen.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/MapViewScreen.kt
@@ -3,43 +3,38 @@ package com.android.hangyul.ui.screen.routine
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Marker
 import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.CameraPositionState
 import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 
 
 @Composable
-fun MapViewScreen(markerPosition: LatLng?) {
-    val context = LocalContext.current
-    val busanLatLng = LatLng(35.1796, 129.0756)
-
-    val cameraPositionState = rememberCameraPositionState {
-        position = CameraPosition.fromLatLngZoom(busanLatLng, 13f)
-    }
-
-    if(context != null) {
-        GoogleMap(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(1f),  // 비율 조정
-            cameraPositionState = cameraPositionState
-        ) {
-            markerPosition?.let{
-                Marker(
-                    state = MarkerState(position = busanLatLng),
-                    title = "부산",
-                    snippet = "대한민국"
-                )
-            }
-
+fun MapViewScreen(
+    markerPositions: List<LatLng>,
+    cameraPositionState: CameraPositionState
+) {
+    GoogleMap(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(1f),
+        cameraPositionState = cameraPositionState
+    ) {
+        markerPositions.forEachIndexed { index, position ->
+            Marker(
+                state = MarkerState(position = position),
+                title = "선택된 장소 ${index + 1}",
+                snippet = "위도: ${position.latitude}, 경도: ${position.longitude}"
+            )
         }
     }
-
 }
 

--- a/app/src/main/java/com/android/hangyul/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/android/hangyul/viewmodel/MapViewModel.kt
@@ -4,14 +4,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.android.hangyul.ui.screen.routine.location
 import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 
-class MapViewModel : ViewModel(){
-    var selectedLocation by mutableStateOf<LatLng?> (null)
-        private set
+class MapViewModel : ViewModel() {
+    private val _selectedLocations = MutableStateFlow<List<LatLng>>(emptyList())
+    val selectedLocations = _selectedLocations.asStateFlow()
 
-    fun setLocation(latLng: LatLng) {
-        selectedLocation = latLng
+    fun addLocation(location: LatLng) {
+        _selectedLocations.value = _selectedLocations.value + location
     }
 }


### PR DESCRIPTION
### 개요
자주 가는 위치 등록 페이지의 기능 구현

### 목적
- 위치 등록 페이지에서 추가 버튼 누르면 리스트 페이지로 정보 이동
- 핑을 연속해서 여러 개 찍으면 지도에 여러 핑 나오도록 리스트 형식

### 변경사항
- mapViewModel 파라미터 자료형 변경
- api key가 개인키라 깃허브에 바로 올리면 보안 문제 발생 (-> local.properties 에 정의 후 빌드할 때 들고오는 방식으로 변경)
- 지도 페이지 topBar '한결이' -> '일상 관리' 텍스트 변경 (MainActivity.kt 파일에 라우터별 텍스트 추가)

### (옵션) 화면 이미지 등
<img width="181" alt="image" src="https://github.com/user-attachments/assets/fa0e52dc-c424-4269-91ca-ca78d303db90" />
ㄴ 부산대랑 톤쇼우 위치 추가한 페이지 화면 