### PR TITLE
chore:추억등록 페이지 텍스트 필드 중앙 정렬 및 간격 조정

### DIFF
--- a/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryAddPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryAddPage.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
@@ -64,9 +65,26 @@ fun MemoryAddPage(viewModel: MemoryViewModel, onSave: ()->Unit) {
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("제목") })
-        OutlinedTextField(value = date, onValueChange = { date = it }, label = { Text("날짜") })
-        OutlinedTextField(value = content, onValueChange = { content = it }, label = { Text("내용") })
+        OutlinedTextField(
+            value = title,
+            onValueChange = { title = it },
+            label = { Text("제목") },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        OutlinedTextField(
+            value = date,
+            onValueChange = { date = it },
+            label = { Text("날짜") },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        OutlinedTextField(
+            value = content,
+            onValueChange = { content = it },
+            label = { Text("내용") },
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+        )
 
 
         Spacer(modifier = Modifier.height(10.dp))


### PR DESCRIPTION
### 개요
- 추억 등록 페이지 디자인 일부 수정
### 목적
- 기기에 따라 입력 필드가 한 쪽으로 치우쳐서 화면에 나타남을 수정하기 위함
### 변경사항
- MemoryAddPage.kt에 modifier = Modifier.align(Alignment.CenterHorizontally) 속성 추가 
### (옵션) 화면 이미지 등
![image](https://github.com/user-attachments/assets/4396af66-05a2-493b-8fc8-6066cc340ffb)
