### PR TITLE
feature:음성일기 기능 네비게이션 구현

### DIFF
--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -13,6 +13,8 @@ import com.android.hangyul.ui.screen.braintraining.BrainTrainingInitialPage
 import com.android.hangyul.ui.screen.braintraining.BrainTrainingAnswerPage
 import com.android.hangyul.ui.screen.braintraining.BrainTrainingResultPage
 import com.android.hangyul.ui.screen.diary.DiaryPage
+import com.android.hangyul.ui.screen.diary.DiaryHistoryPage
+import com.android.hangyul.ui.screen.diary.DiaryDetailPage
 import com.android.hangyul.ui.screen.main.MainPage
 import com.android.hangyul.ui.screen.memory.MemoryAddPage
 import com.android.hangyul.ui.screen.memory.MemoryDetailPage
@@ -25,6 +27,9 @@ import com.android.hangyul.ui.screen.routine.RoutinePage
 import com.android.hangyul.viewmodel.AlarmViewModel
 import com.android.hangyul.viewmodel.MapViewModel
 import com.android.hangyul.viewmodel.MemoryViewModel
+import com.android.hangyul.ui.screen.diary.DiaryEntry
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 private object Routes {
     const val MAIN = "main"
@@ -33,6 +38,8 @@ private object Routes {
     const val BRAIN_RESULT = "brain_result"
     const val ROUTINE = "routine"
     const val DIARY = "diary"
+    const val DIARY_DETAIL = "diaryDetail/{date}"
+    const val DIARY_HISTORY = "diaryHistory"
     const val MEMORY = "memory"
 
     const val ALARM_LIST = "alarmList"
@@ -49,6 +56,33 @@ private object Routes {
 fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
     val sharedMapViewModel: MapViewModel = viewModel()
     val sharedMemoryViewModel: MemoryViewModel = viewModel()
+
+    // 오늘 날짜 더미 데이터 생성
+    val today = LocalDate.now()
+    val dateForRoute = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+    val dummyEntries = listOf(
+        DiaryEntry(
+            date = dateForRoute,
+            emoji = "😊",
+            emotion = "행복",
+            content = "오늘은 정말 즐거운 하루였다!" ,
+            comment = "내일도 행복하세요"
+        ),
+        DiaryEntry(
+            date = "2025-06-05",
+            emoji = "💖",
+            emotion = "사랑",
+            content = "아들아 사랑한다.",
+            comment = "사랑이 넘치는 하루를 보내셨군요"
+        ),
+        DiaryEntry(
+            date = "2025-06-04",
+            emoji = "😠",
+            emotion = "분노",
+            content = "마누라랑 싸웠다.. 하ㅏ.. 내일 화해해야지.",
+            comment = "내일은 꼭 화해하세요!"
+        )
+    )
 
     NavHost(navController = navController, startDestination = Routes.MAIN, modifier = modifier) {
         composable(Routes.MAIN) { MainPage(navController) }
@@ -91,7 +125,30 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
             }
         }
         composable(Routes.ROUTINE) { RoutinePage(navController) }
-        composable(Routes.DIARY) { DiaryPage(navController) }
+        composable(Routes.DIARY) {
+            DiaryPage(navController, entries = dummyEntries, fileName = "오늘의일기.mp3")
+        }
+        composable(Routes.DIARY_HISTORY) {
+            DiaryHistoryPage(entries = dummyEntries, onEntryClick = { entry ->
+                navController.navigate("diaryDetail/${entry.date}")
+            })
+        }
+        composable(
+            route = "diaryDetail/{date}",
+        ) { backStackEntry ->
+            val date = backStackEntry.arguments?.getString("date") ?: ""
+            val entry = dummyEntries.find { it.date == date }
+            if (entry != null) {
+                DiaryDetailPage(
+                    date = entry.date,
+                    convertedText = entry.content,
+                    emotion = "${entry.emoji} ${entry.emotion}",
+                    emotionComment = "${entry.comment}"
+                )
+            } else {
+                androidx.compose.material3.Text("해당 날짜의 일기가 없습니다.")
+            }
+        }
 
         composable(Routes.ALARM_LIST) { AlarmListPage(navController) }
         composable(Routes.ALARM_ADD) {

--- a/app/src/main/java/com/android/hangyul/ui/screen/diary/DiaryHistoryCard.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/diary/DiaryHistoryCard.kt
@@ -32,14 +32,15 @@ data class DiaryEntry(
     val date: String,
     val emoji: String,
     val emotion: String,
-    val content: String
+    val content: String,
+    val comment : String
 )
 @Composable
 fun DiaryHistoryCard(
     entries: List<DiaryEntry>,
     modifier: Modifier = Modifier,
-    onHeaderClick: () ->Unit = {},
-    onEntryClick: (DiaryEntry) -> Unit = {}
+    onHeaderClick: () ->Unit = {}, // 헤더(제목) 클릭 시 호출
+    onEntryClick: (DiaryEntry) -> Unit = {} // 엔트리(기록 카드) 클릭 시 호출
 ) {
     Column(
         modifier = modifier
@@ -78,8 +79,8 @@ fun DiaryHistoryCard(
 @Composable
 fun DiaryHistoryCardPreview() {
     val dummyEntries = listOf(
-        DiaryEntry("5월 26일", "😊", "행복", "오늘은 기분이 좋았어요!"),
-        DiaryEntry("5월 25일", "🥺", "슬픔", "오늘은 혼자있는 시간이 많았나봐요")
+        DiaryEntry("5월 26일", "😊", "행복", "오늘은 기분이 좋았어요!",""),
+        DiaryEntry("5월 25일", "🥺", "슬픔", "오늘은 혼자있는 시간이 많았나봐요","")
     )
 
     HangyulTheme {

--- a/app/src/main/java/com/android/hangyul/ui/screen/diary/DiaryHistoryPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/diary/DiaryHistoryPage.kt
@@ -69,11 +69,11 @@ fun DiaryHistoryPage(
 @Composable
 fun DiaryHistoryPagePreview() {
         val dummyEntries = listOf(
-            DiaryEntry("5월 26일", "😊", "행복", "오늘은 기분이 좋았어요!"),
-            DiaryEntry("5월 25일", "💖", "사랑", "아드님과 좋은 시간을 보내셨나봐요."),
-            DiaryEntry("5월 24일", "😢", "슬픔", "오늘은 혼자있는 시간이 많았나봐요"),
-            DiaryEntry("5월 23일", "💖", "설렘", "내일도 행복하길 바라요~"),
-            DiaryEntry("5월 22일", "😢", "슬픔", "오늘은 혼자있는 시간이 많았나봐요")
+            DiaryEntry("5월 26일", "😊", "행복", "오늘은 기분이 좋았어요!","위로 멘트"),
+            DiaryEntry("5월 25일", "💖", "사랑", "아드님과 좋은 시간을 보내셨나봐요.","위로 멘트"),
+            DiaryEntry("5월 24일", "😢", "슬픔", "오늘은 혼자있는 시간이 많았나봐요","위로 멘트"),
+            DiaryEntry("5월 23일", "💖", "설렘", "내일도 행복하길 바라요~","위로 멘트"),
+            DiaryEntry("5월 22일", "😢", "슬픔", "오늘은 혼자있는 시간이 많았나봐요","위로 멘트")
         )
         HangyulTheme {
             DiaryHistoryPage(entries = dummyEntries)

--- a/app/src/main/java/com/android/hangyul/ui/screen/diary/DiaryPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/diary/DiaryPage.kt
@@ -37,6 +37,7 @@ fun DiaryPage(
 ) {
     val today = remember { LocalDate.now() }
     val formattedDate = today.format(DateTimeFormatter.ofPattern("yyyy년 M월 d일 (E)", Locale.KOREAN))
+    val dateForRoute = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
     val recordingState = remember { mutableStateOf(RecordingState.Idle) }
     val duration = remember { mutableStateOf("00:00") }
 
@@ -71,7 +72,7 @@ fun DiaryPage(
                 fileName = fileName,
                 onClick = {
                     if (!fileName.isNullOrBlank()) {
-                        navController.navigate("detail/2025-05-27")
+                        navController.navigate("diaryDetail/$dateForRoute")
                     }
                 }
             )
@@ -80,9 +81,9 @@ fun DiaryPage(
 
             DiaryHistoryCard(
                 entries = entries,
-                onHeaderClick = { navController.navigate("history") },
+                onHeaderClick = { navController.navigate("diaryHistory") },
                 onEntryClick = { entry ->
-                    navController.navigate("detail/${entry.date}")
+                    navController.navigate("diaryDetail/${entry.date}")
                 }
             )
 
@@ -95,8 +96,8 @@ fun DiaryPage(
 @Composable
 fun DiaryPagePreview() {
     val dummyEntries = listOf(
-        DiaryEntry("5월 26일", "😊", "행복", "오늘은 기분이 좋았어요!"),
-        DiaryEntry("5월 25일", "🥺", "슬픔", "오늘은 혼자있는 시간이 많았나봐요")
+        DiaryEntry("5월 26일", "😊", "행복", "오늘은 기분이 좋았어요!","위로"),
+        DiaryEntry("5월 25일", "🥺", "슬픔", "오늘은 혼자있는 시간이 많았나봐요","위로")
     )
 
     HangyulTheme {

--- a/app/src/main/java/com/android/hangyul/ui/screen/diary/MiniDiaryCard.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/diary/MiniDiaryCard.kt
@@ -94,7 +94,8 @@ fun SimpleDiaryCardPreview() {
                 date = "5월 27일",
                 emoji = "😊",
                 emotion = "행복",
-                content = "오늘은 기분이 좋았어요!"
+                content = "오늘은 기분이 좋았어요!",
+                comment = "위로 멘트"
             )
         )
     }


### PR DESCRIPTION
# 개요 
- 음성일기 페이지 내부 네비게이션 구현
# 목적
- 내부에서 하루의 일기 (DiaryDetailPage)로 이동 구현
- 일기기록 (DiaryHistoryPage) 로 이동 구현
# 변경 사항
- navgraph파일 변경, 
- diaryEntry에 comment (위로 멘트) 항목 추가
# ps
- 아직 녹음 기능이 구현 안됐기 때문에 데이터가 없어서 더미데이터 3건 정도 만들어서 history , detail 페이지 볼 수 있도록 함 
# 사진 
<p align="center">
  <img src="https://github.com/user-attachments/assets/bcc6857d-b2f5-4959-b549-146d92386952" width="200"/>
  <img src="https://github.com/user-attachments/assets/06ad67ce-e1f3-4c69-bec5-804efe8958f4" width="200"/>
  <img src="https://github.com/user-attachments/assets/c57e1e76-1532-47fe-af37-1f386f7b4110" width="200"/>
</p>
