### PR TITLE
fix: 모든 페이지 topBar 텍스트 수정

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/android/hangyul/MainActivity.kt
+++ b/app/src/main/java/com/android/hangyul/MainActivity.kt
@@ -30,18 +30,16 @@ class MainActivity : ComponentActivity() {
                     .currentBackStackEntryAsState().value
                     ?.destination?.route
 
-                val topBarTitle = when (currentRoute) {
-                    "main" -> "한결이"
-                    "diary" -> "음성 일기"
-                    "routine" -> "일상 관리"
-                    "brainTraining" -> "두뇌 훈련"
-                    "memory" -> "추억 기록"
-                    "alarmList" -> "일상 관리"
-                    "alarmAdd" -> "일상 관리"
-                    "memoryDetail/{memoryId}" -> "추억 기록"
-                    "memoryAdd" -> "추억 기록"
-                    "mapList" -> "일상 관리"
-                    "mapAdd" -> "일상 관리"
+                val topBarTitle = when {
+                    currentRoute == "main" -> "한결이"
+                    currentRoute?.startsWith("diary") == true -> "음성 일기"
+                    currentRoute?.startsWith("routine") == true -> "일상 관리"
+                    currentRoute?.startsWith("brainTraining") == true -> "두뇌 훈련"
+                    currentRoute?.startsWith("brain_answer") == true -> "두뇌 훈련"
+                    currentRoute?.startsWith("brain_result") == true -> "두뇌 훈련"
+                    currentRoute?.startsWith("memory") == true -> "추억 기록"
+                    currentRoute?.startsWith("alarm") == true -> "일상 관리"
+                    currentRoute?.startsWith("map") == true -> "일상 관리"
                     else -> "한결이"
                 }
 
@@ -50,7 +48,7 @@ class MainActivity : ComponentActivity() {
                         if (currentRoute != "main") {
                             TopBar(topBarTitle)
                         }
-                             },
+                    },
                     bottomBar = {NaviBar(navController)})
                 { innerPadding ->
                     NavGraph(

--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -38,14 +38,12 @@ private object Routes {
     const val BRAIN_RESULT = "brain_result"
     const val ROUTINE = "routine"
     const val DIARY = "diary"
-    const val DIARY_DETAIL = "diaryDetail/{date}"
     const val DIARY_HISTORY = "diaryHistory"
     const val MEMORY = "memory"
 
     const val ALARM_LIST = "alarmList"
     const val ALARM_ADD = "alarmAdd"
 
-    const val MEMORY_DETAIL = "memoryDetail/{memoryId}"
     const val MEMORY_ADD = "memoryAdd"
 
     const val MAP_LIST = "mapList"


### PR DESCRIPTION
### 개요
각 페이지의 topBar에 나오는 텍스트 페이지에 맞게 적용

### 목적
페이지마다 라우터를 정의해서 텍스트 적용한 방법
-> startsWith로 간접적 적용

### 변경사항
- 두뇌훈련이나 음성 일기의 라우터가 외부 값을 받아오는 형식이라 기존의 방법으로는 따로 정의하기가 어려움
- startsWith('파라미터') 형식으로 '파라미터'로 시작하는 라우터인 경우 해당 텍스트 적용하는 것으로 변경
- 모든 페이지 topBar 알맞게 적용 완!
- 불필요한 코드 삭제

### 이미지
<img width="176" alt="image" src="https://github.com/user-attachments/assets/943d5ffd-fafa-4054-b62e-85b67303e457" />
