### PR TITLE
feat : 알람 앱 연동 및 등록 기능 구현 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
 
 
     <application

--- a/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
+++ b/app/src/main/java/com/android/hangyul/navigation/NavGraph.kt
@@ -54,6 +54,7 @@ private object Routes {
 fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
     val sharedMapViewModel: MapViewModel = viewModel()
     val sharedMemoryViewModel: MemoryViewModel = viewModel()
+    val alarmViewModel : AlarmViewModel = viewModel()
 
     // 오늘 날짜 더미 데이터 생성
     val today = LocalDate.now()
@@ -148,9 +149,9 @@ fun NavGraph(navController: NavHostController, modifier: Modifier = Modifier) {
             }
         }
 
-        composable(Routes.ALARM_LIST) { AlarmListPage(navController) }
+        composable(Routes.ALARM_LIST) { AlarmListPage(navController, viewModel = alarmViewModel) }
         composable(Routes.ALARM_ADD) {
-            AlarmAddPage(viewModel = viewModel()) {
+            AlarmAddPage(viewModel = alarmViewModel) {
                 navController.popBackStack()
             }
         }

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmAddPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmAddPage.kt
@@ -47,10 +47,6 @@ fun AlarmAddPage(viewModel: AlarmViewModel, onSave: ()->Unit) {
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally
         ){
-            AddInputField(
-                text = viewModel.alarmName,
-                onTextChanged = { viewModel.alarmName = it },
-                placeholderText = "알람 이름")
             Spacer(modifier = Modifier.height(10.dp))
             AddInputField(
                 text = viewModel.medicineName,
@@ -75,6 +71,7 @@ fun AlarmAddPage(viewModel: AlarmViewModel, onSave: ()->Unit) {
         TimePicker { hour, minute ->
             viewModel.hour = hour
             viewModel.minute = minute
+            viewModel.addAlarm()
             onSave()
         }
 

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmAddPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmAddPage.kt
@@ -22,9 +22,17 @@ import androidx.compose.ui.unit.sp
 import com.android.hangyul.R
 import com.android.hangyul.ui.components.AddInputField
 import com.android.hangyul.viewmodel.AlarmViewModel
+import android.content.Intent
+import android.provider.AlarmClock
+import android.util.Log
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
+import com.google.android.datatransport.runtime.util.PriorityMapping.toInt
 
 @Composable
 fun AlarmAddPage(viewModel: AlarmViewModel, onSave: ()->Unit) {
+
+    val context = LocalContext.current
 
     Column (
         modifier = Modifier
@@ -68,10 +76,23 @@ fun AlarmAddPage(viewModel: AlarmViewModel, onSave: ()->Unit) {
 
         Spacer(modifier = Modifier.height(40.dp))
 
-        TimePicker { hour, minute ->
+        TimePicker { hour, minute->
+
             viewModel.hour = hour
             viewModel.minute = minute
+            val medicine = viewModel.medicineName
             viewModel.addAlarm()
+
+            Log.d("AlarmDebug", "알람 설정 전: hour=$hour, minute=$minute")
+
+
+            val intent = Intent(AlarmClock.ACTION_SET_ALARM).apply {
+                putExtra(AlarmClock.EXTRA_HOUR, hour)
+                putExtra(AlarmClock.EXTRA_MINUTES, minute)
+                putExtra(AlarmClock.EXTRA_MESSAGE, medicine.ifBlank { "약 복용 시간" })
+            }
+            context.startActivity(intent)
+
             onSave()
         }
 

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmList.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmList.kt
@@ -2,6 +2,7 @@ package com.android.hangyul.ui.screen.routine
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -21,11 +22,14 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
 import com.android.hangyul.R
 import com.android.hangyul.ui.theme.Purple80
+import androidx.compose.runtime.*
+
 
 @Composable
-fun AlarmList(hour: Int, min: Int, text: String) {
+fun AlarmList(hour:Int, min: Int, text: String, onDelete : () -> Unit) {
     Row (
         modifier = Modifier
             .fillMaxWidth()
@@ -45,7 +49,7 @@ fun AlarmList(hour: Int, min: Int, text: String) {
 
         Column {
             Text(
-                text = "${hour}:${min}",
+                text = String.format("%02d:%02d", hour, min),
                 style = TextStyle(
                     fontSize = 35.sp,
                     lineHeight = 24.sp,
@@ -72,13 +76,10 @@ fun AlarmList(hour: Int, min: Int, text: String) {
             modifier = Modifier
                 .padding(end = 30.dp)
                 .size(40.dp)
+                .clickable {
+                    onDelete()
+                }
 
         )
     }
-}
-
-@Preview
-@Composable
-fun AlarmListPreview() {
-    AlarmList(13,30,"오메가3")
 }

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmListPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmListPage.kt
@@ -12,7 +12,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Alignment
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusModifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -22,9 +29,13 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.android.hangyul.R
 import com.android.hangyul.ui.components.AddBtn
+import com.android.hangyul.viewmodel.AlarmItem
+import com.android.hangyul.viewmodel.AlarmViewModel
 
 @Composable
-fun AlarmListPage(navController: NavController) {
+fun AlarmListPage(navController: NavController, viewModel: AlarmViewModel) {
+    val alarms by viewModel.alarms.collectAsState()
+
     Column (
         modifier = Modifier
             .fillMaxSize()
@@ -40,11 +51,19 @@ fun AlarmListPage(navController: NavController) {
             )
         )
 
-        Spacer(modifier = Modifier.height(22.dp))
+        Spacer(modifier = Modifier.height(20.dp))
 
-        AlarmList(13,30,"오메가3")
-        Spacer(modifier = Modifier.height(10.dp))
-        AlarmList(18, 30, "비타민")
+        alarms.forEach { alarm ->
+            AlarmList(
+                navController = navController,
+                hour = alarm.hour,
+                min = alarm.minute,
+                text = alarm.medicineName,
+                onDelete = { viewModel.deleteAlarm(alarm.id) }
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+        }
+
 
         Spacer(modifier = Modifier.weight(1f))
 
@@ -56,6 +75,7 @@ fun AlarmListPage(navController: NavController) {
         ) {
             AddBtn("알람 등록", modifier = Modifier.clickable { navController.navigate("alarmAdd") })
         }
+
     }
 
 }

--- a/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmListPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/routine/AlarmListPage.kt
@@ -55,7 +55,6 @@ fun AlarmListPage(navController: NavController, viewModel: AlarmViewModel) {
 
         alarms.forEach { alarm ->
             AlarmList(
-                navController = navController,
                 hour = alarm.hour,
                 min = alarm.minute,
                 text = alarm.medicineName,

--- a/app/src/main/java/com/android/hangyul/viewmodel/AlarmViewModel.kt
+++ b/app/src/main/java/com/android/hangyul/viewmodel/AlarmViewModel.kt
@@ -4,18 +4,42 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.UUID
+
+data class AlarmItem(
+    val id: String = UUID.randomUUID().toString(),
+    val hour: Int,
+    val minute: Int,
+    val medicineName: String
+)
 
 class AlarmViewModel : ViewModel() {
-    var alarmName by mutableStateOf("")
-    var medicineName by mutableStateOf("")
     var hour by mutableStateOf(0)
     var minute by mutableStateOf(0)
+    var medicineName by mutableStateOf("")
 
+    private val _alarms = MutableStateFlow<List<AlarmItem>>(emptyList())
+    val alarms = _alarms.asStateFlow()
+
+    fun addAlarm() {
+        val alarm = AlarmItem(
+            hour = hour,
+            minute = minute,
+            medicineName = medicineName,
+        )
+        _alarms.value = _alarms.value + alarm
+        reset()
+    }
+
+    fun deleteAlarm(id: String) {
+        _alarms.value = _alarms.value.filterNot { it.id == id }
+    }
 
     fun reset() {
-        alarmName = ""
-        medicineName = ""
         hour = 0
         minute = 0
+        medicineName = ""
     }
 }


### PR DESCRIPTION
### 개요
일상관리/알람 등록 페이지 기능 구현 

### 목적
- 하드코딩 되어 있던 UI 데이터를 viewModel로 연결
- (외부 앱 연결) 앱 내부에서 등록한 데이터를 외부 알람 앱으로 연결해서 등록

### 변경사항
- alarmViewModel 수정
- manifest 파일 uses-permission 추가
- 등록한 시,분,알람 이름을 알람 앱에서도 자동 등록되어 알람 추가될 수 있도록 구현 

### 화면 이미지
<img width="156" alt="스크린샷 2025-06-08 144841" src="https://github.com/user-attachments/assets/89e5cd84-172f-4a6a-9b7b-f66c53238aa0" />

이렇게 등록하면 
<img width="158" alt="스크린샷 2025-06-08 144907" src="https://github.com/user-attachments/assets/d1698ede-6ef5-46bb-b868-e857c11d2331" />
알람 앱에서 그대로 적용되어 바로 등록됨
<img width="169" alt="스크린샷 2025-06-08 144923" src="https://github.com/user-attachments/assets/c986e549-72ff-4ce1-b0af-159b7a8c8d23" />
우리 앱에서도 등록됨 


