### PR TITLE
fix: 추억 기록 이미지 업로드 버그 수정

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -13,7 +13,6 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryDetailPage.kt
+++ b/app/src/main/java/com/android/hangyul/ui/screen/memory/MemoryDetailPage.kt
@@ -38,6 +38,10 @@ import coil.compose.AsyncImage
 import coil.compose.rememberAsyncImagePainter
 import com.android.hangyul.viewmodel.Memory
 import com.android.hangyul.viewmodel.MemoryViewModel
+import androidx.compose.ui.platform.LocalContext
+import coil.request.ImageRequest
+import java.io.File
+import android.net.Uri
 
 
 @Composable
@@ -85,13 +89,26 @@ fun MemoryDetailPage(navController: NavController,memoryId: String?, viewModel: 
         Spacer(modifier = Modifier.height(20.dp))
 
         memory.imageUrl?.let { imageUrl ->
-            Image(
-                painter = rememberAsyncImagePainter(imageUrl),
-                contentDescription = null,
-                modifier = Modifier
-                    .width(250.dp)
-                    .height(180.dp)
-            )
+            val context = LocalContext.current
+            Log.d("MemoryDetail", "Loading image from path: $imageUrl")
+            
+            val imageFile = File(imageUrl)
+            if (imageFile.exists()) {
+                Image(
+                    painter = rememberAsyncImagePainter(
+                        ImageRequest.Builder(context)
+                            .data(imageFile)
+                            .crossfade(true)
+                            .build()
+                    ),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .width(250.dp)
+                        .height(180.dp)
+                )
+            } else {
+                Log.e("MemoryDetail", "Image file does not exist: $imageUrl")
+            }
         }
 
         Spacer(modifier = Modifier.height(20.dp))


### PR DESCRIPTION
등록하고 바로 볼 때는 이미지 나오는데
재부팅하면 contentprovider 뜨면서 이미지 안 나오는 버그 수정
-> content:// 로 저장되던 주소를 firestore도 접근 가능한 주소로 변경 

(원인: firestore는 content:// 주소의 이미지 url 을 불러올 수 없기 때문...)